### PR TITLE
fix: handle all-negative-criteria rubrics returning zero score

### DIFF
--- a/src/rubric/autograders/per_criterion_grader.py
+++ b/src/rubric/autograders/per_criterion_grader.py
@@ -188,6 +188,9 @@ class PerCriterionGrader(Autograder):
         self, judge_results: list[CriterionReport], *, normalize: bool = True
     ) -> EvaluationReport:
         total_positive_weight = sum(max(0.0, report.weight) for report in judge_results)
+        total_negative_weight = sum(
+            abs(report.weight) for report in judge_results if report.weight < 0
+        )
         weighted_score_sum = sum(
             (1.0 if report.verdict == "MET" else 0.0) * report.weight for report in judge_results
         )
@@ -197,6 +200,11 @@ class PerCriterionGrader(Autograder):
         if normalize:
             if total_positive_weight > 0:
                 score = max(0.0, min(1.0, weighted_score_sum / total_positive_weight))
+            elif total_negative_weight > 0:
+                # All-negative rubric: score starts at 1.0, errors (MET) subtract from it
+                # weighted_score_sum is <= 0 for all-negative rubrics
+                # Formula: 1.0 + (negative_sum / total_negative) gives 1.0 when no errors, 0.0 when all errors
+                score = max(0.0, min(1.0, 1.0 + weighted_score_sum / total_negative_weight))
             else:
                 score = 0.0
         else:

--- a/tests/autograders/test_per_criterion_grader_class.py
+++ b/tests/autograders/test_per_criterion_grader_class.py
@@ -1,5 +1,8 @@
+import json
+
 import pytest
 
+from rubric import Criterion, Rubric
 from rubric.autograders import PerCriterionGrader
 from rubric.types import EvaluationReport
 
@@ -71,3 +74,97 @@ async def test_per_criterion_grader_with_negative_criterion_unmet(sample_rubric)
     assert report.report is not None
     verdicts = [criterion.verdict for criterion in report.report]
     assert verdicts == ["MET", "MET", "MET", "UNMET"]
+
+
+@pytest.mark.asyncio
+async def test_all_negative_criteria_all_unmet_returns_perfect_score():
+    """All-negative rubric with no errors present should return 1.0."""
+    rubric = Rubric([
+        Criterion(weight=-1.0, requirement="Contains factual errors"),
+        Criterion(weight=-1.0, requirement="Contains profanity"),
+        Criterion(weight=-1.0, requirement="Contains harmful content"),
+    ])
+
+    async def generate_no_errors(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"criterion_status": "UNMET", "explanation": "Error not present"})
+
+    grader = PerCriterionGrader(generate_fn=generate_no_errors)
+    result = await rubric.grade("Clean, accurate text", autograder=grader)
+
+    assert result.score == pytest.approx(1.0)
+    assert result.raw_score == pytest.approx(0.0)
+    assert all(r.verdict == "UNMET" for r in result.report)
+
+
+@pytest.mark.asyncio
+async def test_all_negative_criteria_all_met_returns_zero_score():
+    """All-negative rubric with all errors present should return 0.0."""
+    rubric = Rubric([
+        Criterion(weight=-1.0, requirement="Contains factual errors"),
+        Criterion(weight=-1.0, requirement="Contains profanity"),
+        Criterion(weight=-1.0, requirement="Contains harmful content"),
+    ])
+
+    async def generate_all_errors(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"criterion_status": "MET", "explanation": "Error is present"})
+
+    grader = PerCriterionGrader(generate_fn=generate_all_errors)
+    result = await rubric.grade("Bad text with errors", autograder=grader)
+
+    assert result.score == pytest.approx(0.0)
+    assert result.raw_score == pytest.approx(-3.0)
+    assert all(r.verdict == "MET" for r in result.report)
+
+
+@pytest.mark.asyncio
+async def test_all_negative_criteria_partial_errors_returns_partial_score():
+    """All-negative rubric with some errors should return partial score."""
+    rubric = Rubric([
+        Criterion(weight=-1.0, requirement="Contains factual errors"),
+        Criterion(weight=-1.0, requirement="Contains profanity"),
+        Criterion(weight=-1.0, requirement="Contains harmful content"),
+    ])
+
+    call_count = 0
+
+    async def generate_one_error(system_prompt: str, user_prompt: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        # First criterion has error, others don't
+        if call_count == 1:
+            return json.dumps({"criterion_status": "MET", "explanation": "Error is present"})
+        return json.dumps({"criterion_status": "UNMET", "explanation": "Error not present"})
+
+    grader = PerCriterionGrader(generate_fn=generate_one_error)
+    result = await rubric.grade("Text with one error", autograder=grader)
+
+    # 1 error out of 3: score = 1.0 + (-1.0 / 3.0) = 2/3 ≈ 0.667
+    assert result.score == pytest.approx(2.0 / 3.0)
+    assert result.raw_score == pytest.approx(-1.0)
+
+
+@pytest.mark.asyncio
+async def test_all_negative_criteria_with_different_weights():
+    """All-negative rubric with varying weights should weight errors appropriately."""
+    rubric = Rubric([
+        Criterion(weight=-2.0, requirement="Contains major factual errors"),
+        Criterion(weight=-1.0, requirement="Contains minor typos"),
+    ])
+
+    call_count = 0
+
+    async def generate_minor_error_only(system_prompt: str, user_prompt: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        # Only the minor error (second criterion) is present
+        if call_count == 2:
+            return json.dumps({"criterion_status": "MET", "explanation": "Minor error present"})
+        return json.dumps({"criterion_status": "UNMET", "explanation": "Error not present"})
+
+    grader = PerCriterionGrader(generate_fn=generate_minor_error_only)
+    result = await rubric.grade("Text with minor error", autograder=grader)
+
+    # total_negative_weight = 3.0, weighted_score_sum = -1.0
+    # score = 1.0 + (-1.0 / 3.0) = 2/3 ≈ 0.667
+    assert result.score == pytest.approx(2.0 / 3.0)
+    assert result.raw_score == pytest.approx(-1.0)

--- a/tests/autograders/test_per_criterion_one_shot_grader_class.py
+++ b/tests/autograders/test_per_criterion_one_shot_grader_class.py
@@ -1,5 +1,8 @@
+import json
+
 import pytest
 
+from rubric import Criterion, Rubric
 from rubric.autograders import PerCriterionOneShotGrader
 
 
@@ -70,3 +73,53 @@ async def test_per_criterion_one_shot_grader_with_negative_criterion_unmet(sampl
     assert report.report is not None
     verdicts = [criterion.verdict for criterion in report.report]
     assert verdicts == ["MET", "MET", "MET", "UNMET"]
+
+
+@pytest.mark.asyncio
+async def test_all_negative_criteria_all_unmet_returns_perfect_score():
+    """All-negative rubric with no errors present should return 1.0."""
+    rubric = Rubric([
+        Criterion(weight=-1.0, requirement="Contains factual errors"),
+        Criterion(weight=-1.0, requirement="Contains profanity"),
+        Criterion(weight=-1.0, requirement="Contains harmful content"),
+    ])
+
+    async def generate_no_errors(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({
+            "criteria_evaluations": [
+                {"criterion_number": 1, "criterion_status": "UNMET", "explanation": "No errors"},
+                {"criterion_number": 2, "criterion_status": "UNMET", "explanation": "No profanity"},
+                {"criterion_number": 3, "criterion_status": "UNMET", "explanation": "No harmful content"},
+            ]
+        })
+
+    grader = PerCriterionOneShotGrader(generate_fn=generate_no_errors)
+    result = await rubric.grade("Clean, accurate text", autograder=grader)
+
+    assert result.score == pytest.approx(1.0)
+    assert result.raw_score == pytest.approx(0.0)
+    assert all(r.verdict == "UNMET" for r in result.report)
+
+
+@pytest.mark.asyncio
+async def test_all_negative_criteria_all_met_returns_zero_score():
+    """All-negative rubric with all errors present should return 0.0."""
+    rubric = Rubric([
+        Criterion(weight=-1.0, requirement="Contains factual errors"),
+        Criterion(weight=-1.0, requirement="Contains profanity"),
+    ])
+
+    async def generate_all_errors(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({
+            "criteria_evaluations": [
+                {"criterion_number": 1, "criterion_status": "MET", "explanation": "Has errors"},
+                {"criterion_number": 2, "criterion_status": "MET", "explanation": "Has profanity"},
+            ]
+        })
+
+    grader = PerCriterionOneShotGrader(generate_fn=generate_all_errors)
+    result = await rubric.grade("Bad text", autograder=grader)
+
+    assert result.score == pytest.approx(0.0)
+    assert result.raw_score == pytest.approx(-2.0)
+    assert all(r.verdict == "MET" for r in result.report)


### PR DESCRIPTION
## Summary

- Fixes scoring bug where rubrics containing only negative criteria always returned `0.0`
- Adds proper handling for all-negative rubrics using the formula: `1.0 + (weighted_score_sum / total_negative_weight)`
- Adds comprehensive tests for all-negative criteria scenarios

## Problem

Rubrics with only negative criteria (e.g., error detection, safety checks) were broken:

```python
rubric = Rubric([
    Criterion(weight=-1.0, requirement="Contains factual errors"),
    Criterion(weight=-1.0, requirement="Contains profanity"),
])
# Always returned 0.0, even when all errors were avoided
```

This happened because `total_positive_weight` was 0, causing the score to default to `0.0`.

## Solution

Added handling for all-negative rubrics:
- When `total_positive_weight == 0` and `total_negative_weight > 0`, use: `score = 1.0 + (weighted_score_sum / total_negative_weight)`
- This gives `1.0` when no errors (all UNMET), `0.0` when all errors (all MET)

## Test plan

- [x] `test_all_negative_criteria_all_unmet_returns_perfect_score` - verifies score=1.0 when no errors
- [x] `test_all_negative_criteria_all_met_returns_zero_score` - verifies score=0.0 when all errors  
- [x] `test_all_negative_criteria_partial_errors_returns_partial_score` - verifies proportional scores
- [x] `test_all_negative_criteria_with_different_weights` - verifies weighted scoring
- [x] All 84 existing tests pass

Fixes #1