### PR TITLE
fix: consistent raw_score semantics across all graders

### DIFF
--- a/src/rubric/autograders/per_criterion_grader.py
+++ b/src/rubric/autograders/per_criterion_grader.py
@@ -217,5 +217,6 @@ class PerCriterionGrader(Autograder):
         return EvaluationReport(
             score=score,
             raw_score=raw_score,
+            llm_raw_score=raw_score,  # Same as raw_score for per-criterion graders
             report=judge_results,
         )

--- a/src/rubric/autograders/per_criterion_one_shot_grader.py
+++ b/src/rubric/autograders/per_criterion_one_shot_grader.py
@@ -199,4 +199,9 @@ Provide your evaluation as JSON only."""
         else:
             score = raw_score
 
-        return EvaluationReport(score=score, raw_score=raw_score, report=judge_results)
+        return EvaluationReport(
+            score=score,
+            raw_score=raw_score,
+            llm_raw_score=raw_score,  # Same as raw_score for per-criterion graders
+            report=judge_results,
+        )

--- a/src/rubric/types.py
+++ b/src/rubric/types.py
@@ -113,12 +113,22 @@ class EvaluationReport(BaseModel):
     """Final evaluation result with score and optional per-criterion reports.
 
     For training use cases, set normalize=False in the autograder to get raw weighted sums
-    instead of normalized 0-1 scores. The raw_score field always contains the unnormalized
-    weighted sum regardless of the normalize setting.
+    instead of normalized 0-1 scores.
+
+    Attributes:
+        score: The final score (0-1 if normalized, raw weighted sum otherwise).
+        raw_score: Always contains the unnormalized weighted sum, regardless of grader type.
+            This provides consistent semantics across all graders for training pipelines.
+        llm_raw_score: The original score returned by the LLM before any conversion.
+            For PerCriterionGrader/PerCriterionOneShotGrader: same as raw_score (weighted sum).
+            For RubricAsJudgeGrader: the 0-100 holistic score from the LLM.
+            Useful for debugging and understanding the LLM's actual output.
+        report: Optional per-criterion breakdown (None for RubricAsJudgeGrader).
     """
 
     score: float
     raw_score: float | None = None
+    llm_raw_score: float | None = None
     report: list[CriterionReport] | None = None
 
 

--- a/tests/autograders/test_rubric_as_judge_grader.py
+++ b/tests/autograders/test_rubric_as_judge_grader.py
@@ -1,5 +1,8 @@
+import json
+
 import pytest
 
+from rubric import Criterion, Rubric
 from rubric.autograders import RubricAsJudgeGrader
 
 
@@ -22,12 +25,129 @@ async def test_rubric_as_judge_grader_handles_invalid_json(sample_rubric):
 
     grader = RubricAsJudgeGrader(generate_fn=bad_generate)
 
-    score = await grader.judge(
+    judge_result = await grader.judge(
         to_grade="Example submission",
         rubric=sample_rubric.rubric,
     )
-    assert score == 0.0
+    assert judge_result["llm_score"] == 0.0
 
-    report = await grader.aggregate(score)
+    report = await grader.aggregate(judge_result)
     assert report.score == 0.0
     assert report.report is None
+
+
+@pytest.mark.asyncio
+async def test_rubric_as_judge_grader_raw_score_semantics():
+    """Test that raw_score uses weighted-sum semantics consistent with other graders."""
+    rubric = Rubric([
+        Criterion(weight=10.0, requirement="Is accurate"),
+        Criterion(weight=5.0, requirement="Is helpful"),
+    ])
+
+    async def generate_85(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"overall_score": 85})
+
+    grader = RubricAsJudgeGrader(generate_fn=generate_85)
+    result = await rubric.grade("Test output", autograder=grader)
+
+    # total_positive_weight = 15.0
+    # LLM score = 85/100 = 0.85
+    # Synthetic raw_score = 0.85 * 15.0 = 12.75
+    assert result.raw_score == pytest.approx(12.75)
+    assert result.llm_raw_score == pytest.approx(85.0)
+    assert result.score == pytest.approx(0.85)
+
+
+@pytest.mark.asyncio
+async def test_rubric_as_judge_grader_llm_raw_score_preserved():
+    """Test that llm_raw_score preserves the original 0-100 LLM output."""
+    rubric = Rubric([
+        Criterion(weight=20.0, requirement="Is complete"),
+    ])
+
+    async def generate_70(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"overall_score": 70})
+
+    grader = RubricAsJudgeGrader(generate_fn=generate_70)
+    result = await rubric.grade("Test output", autograder=grader)
+
+    # Original LLM score should be preserved
+    assert result.llm_raw_score == pytest.approx(70.0)
+    # Synthetic raw_score = 0.70 * 20.0 = 14.0
+    assert result.raw_score == pytest.approx(14.0)
+
+
+@pytest.mark.asyncio
+async def test_rubric_as_judge_grader_normalize_false():
+    """Test that normalize=False returns synthetic raw_score, not LLM score."""
+    rubric = Rubric([
+        Criterion(weight=10.0, requirement="Is accurate"),
+        Criterion(weight=5.0, requirement="Is helpful"),
+    ])
+
+    async def generate_80(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"overall_score": 80})
+
+    grader = RubricAsJudgeGrader(generate_fn=generate_80, normalize=False)
+    result = await rubric.grade("Test output", autograder=grader)
+
+    # With normalize=False, score should be the synthetic raw_score
+    # raw_score = 0.80 * 15.0 = 12.0
+    assert result.score == pytest.approx(12.0)
+    assert result.raw_score == pytest.approx(12.0)
+    assert result.llm_raw_score == pytest.approx(80.0)
+
+
+@pytest.mark.asyncio
+async def test_rubric_as_judge_grader_all_negative_rubric():
+    """Test raw_score semantics for all-negative rubrics."""
+    rubric = Rubric([
+        Criterion(weight=-2.0, requirement="Contains factual errors"),
+        Criterion(weight=-3.0, requirement="Contains harmful content"),
+    ])
+
+    # LLM score of 100 means no errors detected
+    async def generate_100(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"overall_score": 100})
+
+    grader = RubricAsJudgeGrader(generate_fn=generate_100)
+    result = await rubric.grade("Perfect output", autograder=grader)
+
+    # For all-negative rubric with score=100 (no errors):
+    # raw_score should be 0 (no penalties)
+    assert result.raw_score == pytest.approx(0.0)
+    assert result.llm_raw_score == pytest.approx(100.0)
+    assert result.score == pytest.approx(1.0)
+
+    # LLM score of 0 means all errors detected
+    async def generate_0(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"overall_score": 0})
+
+    grader_0 = RubricAsJudgeGrader(generate_fn=generate_0)
+    result_0 = await rubric.grade("Bad output", autograder=grader_0)
+
+    # raw_score should be -5.0 (total negative weight)
+    assert result_0.raw_score == pytest.approx(-5.0)
+    assert result_0.llm_raw_score == pytest.approx(0.0)
+    assert result_0.score == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_rubric_as_judge_grader_mixed_rubric():
+    """Test raw_score semantics for mixed positive/negative rubrics."""
+    rubric = Rubric([
+        Criterion(weight=10.0, requirement="Is accurate"),
+        Criterion(weight=-5.0, requirement="Contains errors"),
+    ])
+
+    async def generate_90(system_prompt: str, user_prompt: str) -> str:
+        return json.dumps({"overall_score": 90})
+
+    grader = RubricAsJudgeGrader(generate_fn=generate_90)
+    result = await rubric.grade("Test output", autograder=grader)
+
+    # For mixed rubric, raw_score is based on positive weight only
+    # raw_score = 0.90 * 10.0 = 9.0
+    assert result.raw_score == pytest.approx(9.0)
+    assert result.llm_raw_score == pytest.approx(90.0)
+    assert result.score == pytest.approx(0.90)


### PR DESCRIPTION
## Summary

- Add `llm_raw_score` field to `EvaluationReport` to preserve original LLM output
- Make `raw_score` use consistent weighted-sum semantics across all graders
- `RubricAsJudgeGrader` now converts its 0-100 LLM score to weighted sum for `raw_score`
- Update README with new Score Fields documentation

## Problem

Previously, `raw_score` had different semantics across graders:

| Grader | raw_score Range | Meaning |
|--------|-----------------|---------|
| PerCriterionGrader | (-∞, +∞) | Weighted sum of verdicts |
| PerCriterionOneShotGrader | (-∞, +∞) | Weighted sum of verdicts |
| RubricAsJudgeGrader | [0, 100] | LLM's holistic assessment |

This made `raw_score` incomparable across graders, breaking training pipelines that needed consistent reward signals.

## Solution

- `raw_score` now always uses weighted-sum semantics
- `llm_raw_score` preserves the original LLM output for debugging
- For `RubricAsJudgeGrader`: `raw_score = (llm_score / 100.0) * total_positive_weight`

## Example

```python
# rubric with weights [10.0, 5.0] (total_positive_weight = 15)
result = await rubric.grade(text, autograder=RubricAsJudgeGrader())

result.score          # 0.85 (normalized)
result.raw_score      # 12.75 (weighted sum semantics)
result.llm_raw_score  # 85.0 (original LLM output)
```

## Test plan

- [x] Added tests for `raw_score` conversion in `RubricAsJudgeGrader`
- [x] Added tests for `llm_raw_score` preservation
- [x] Added tests for all-negative rubrics
- [x] All 93 existing tests pass

Fixes #6