### PR TITLE
fix: resolve nested XML ambiguity in thinking/output grading

### DIFF
--- a/src/rubric/autograders/per_criterion_grader.py
+++ b/src/rubric/autograders/per_criterion_grader.py
@@ -113,6 +113,17 @@ Output: "Locations are only in United States and Canada."
 entails no China location without mentioning China."
 }
 
+THINKING AND OUTPUT SECTIONS:
+The submission may contain <thinking> and <output> sections:
+- <thinking>: The model's internal reasoning process before answering
+- <output>: The final response presented to the user
+
+Unless a criterion specifically mentions "reasoning", "thinking", or "thought process",
+evaluate ONLY the <output> section. The thinking section shows how the model arrived
+at its answer but is not part of the user-facing response.
+
+If the submission has no section markers, treat the entire text as the output.
+
 Return only raw JSON starting with {, no back-ticks, no 'json' prefix."""
 
 
@@ -145,9 +156,9 @@ class PerCriterionGrader(Autograder):
 
 {query_text}
 
-<output>
+<submission>
 {to_grade}
-</output>"""
+</submission>"""
 
         try:
             response = await self.generate(

--- a/src/rubric/autograders/per_criterion_one_shot_grader.py
+++ b/src/rubric/autograders/per_criterion_one_shot_grader.py
@@ -69,6 +69,17 @@ For each criterion, provide:
 - A criterion_status (MET or UNMET)
 - An explanation containing a brief justification
 
+THINKING AND OUTPUT SECTIONS:
+The submission may contain <thinking> and <output> sections:
+- <thinking>: The model's internal reasoning process before answering
+- <output>: The final response presented to the user
+
+Unless a criterion specifically mentions "reasoning", "thinking", or "thought process",
+evaluate ONLY the <output> section. The thinking section shows how the model arrived
+at its answer but is not part of the user-facing response.
+
+If the submission has no section markers, treat the entire text as the output.
+
 Do NOT provide an overall score - only evaluate each criterion.
 
 Respond ONLY with valid JSON in this exact format:
@@ -115,16 +126,16 @@ class PerCriterionOneShotGrader(Autograder):
 
         criteria_text = "\n".join(criteria_lines)
         query_text = f"<input>{query}</input>" if query else ""
-        user_prompt = f"""Evaluate the output against the following criteria:
+        user_prompt = f"""Evaluate the submission against the following criteria:
 <criteria>
 {criteria_text}
 </criteria>
 
 {query_text}
 
-<output>
+<submission>
 {to_grade}
-</output>
+</submission>
 
 Provide your evaluation as JSON only."""
 

--- a/src/rubric/autograders/rubric_as_judge_grader.py
+++ b/src/rubric/autograders/rubric_as_judge_grader.py
@@ -66,8 +66,19 @@ criteria (errors absent) contribute nothing
 7. Clamp the result to 0-100 range
 8. Return this single holistic score
 
+THINKING AND OUTPUT SECTIONS:
+The submission may contain <thinking> and <output> sections:
+- <thinking>: The model's internal reasoning process before answering
+- <output>: The final response presented to the user
+
+Unless a criterion specifically mentions "reasoning", "thinking", or "thought process",
+evaluate ONLY the <output> section. The thinking section shows how the model arrived
+at its answer but is not part of the user-facing response.
+
+If the submission has no section markers, treat the entire text as the output.
+
 Think through each criterion carefully in context, apply the appropriate logic for positive \
-vs negative criteria, and compute a final weighted score that reflects how well the output \
+vs negative criteria, and compute a final weighted score that reflects how well the submission \
 satisfies the rubric as a whole.
 
 Respond ONLY with valid JSON in this exact format:
@@ -129,9 +140,9 @@ using the logic from the system prompt, and return a single holistic score from 
 
 {query_text}
 
-<output>
+<submission>
 {to_grade}
-</output>
+</submission>
 
 Return your evaluation as JSON only."""
 


### PR DESCRIPTION
## Summary

- Change outer wrapper tag from `<output>` to `<submission>` to avoid conflicts with inner `<thinking>`/`<output>` section markers
- Add guidance to all three grader system prompts explaining thinking vs output sections
- Default behavior: evaluate only `<output>` section unless criterion specifically mentions reasoning/thinking

## Problem

When grading inputs with thinking/output sections, the system created nested XML tags:

```xml
<output>
<thinking>Model's reasoning here...</thinking>
<output>Model's final answer here...</output>
</output>
```

This ambiguity could confuse the judge LLM, and there was no guidance on how to handle thinking sections.

## Solution

1. **Renamed outer tag** to `<submission>` - no more nesting conflicts
2. **Added guidance** to system prompts:
   ```
   THINKING AND OUTPUT SECTIONS:
   The submission may contain <thinking> and <output> sections:
   - <thinking>: The model's internal reasoning process before answering
   - <output>: The final response presented to the user

   Unless a criterion specifically mentions "reasoning", "thinking", or "thought process",
   evaluate ONLY the <output> section.
   ```

## Test plan

- [x] All 93 existing tests pass
- [x] Changes applied consistently to all three graders

Fixes #10